### PR TITLE
Bump nginx/ngx_mruby of ubuntu14

### DIFF
--- a/Dockerfile.ubuntu14
+++ b/Dockerfile.ubuntu14
@@ -9,8 +9,8 @@ RUN apt-get install -y build-essential devscripts
 RUN apt-get install -y git ruby2.1 rake bison libssl-dev ruby-switch
 RUN ruby-switch --set ruby2.1
 
-ENV NGINX_VERSION 1.9.4
-ENV NGX_MRUBY_VERSION 1.12.14
+ENV NGINX_VERSION 1.9.7
+ENV NGX_MRUBY_VERSION 1.15.0
 
 WORKDIR /usr/local/src
 RUN git clone --branch release-$NGINX_VERSION --depth 1 https://github.com/nginx/nginx.git
@@ -35,10 +35,10 @@ RUN echo 'deb http://nginx.org/packages/mainline/ubuntu/ trusty nginx' >> /etc/a
 RUN echo 'deb-src http://nginx.org/packages/mainline/ubuntu/ trusty nginx' >> /etc/apt/sources.list
 
 RUN apt-get update
-RUN apt-get build-dep -y nginx
+RUN apt-get build-dep -y nginx="$NGINX_VERSION"
 
 WORKDIR /usr/local/src
-RUN apt-get source nginx
+RUN apt-get source nginx="$NGINX_VERSION"
 WORKDIR /usr/local/src/nginx-$NGINX_VERSION
 ADD ngx_mruby/ubuntu14.04/rules.patch /tmp/rules.patch
 ADD ngx_mruby/ubuntu14.04/control.patch /tmp/control.patch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,6 @@ centos7:
 ubuntu14.04:
   dockerfile: Dockerfile.ubuntu14
   build: .
-  command: cp -a /usr/local/src/nginx_1.9.4-1~trusty_amd64.deb /tmp/nginx-ngx_mruby_1.9.4-1~trusty_amd64.deb
+  command: cp -a /usr/local/src/nginx_1.9.7-1~trusty_amd64.deb /tmp/nginx-ngx_mruby_1.9.7-1~trusty_amd64.deb
   volumes:
     - .:/tmp:rw


### PR DESCRIPTION
Build for ubuntu14.04 is failed.
Last lines of output are as below.

```
Step 35 : RUN patch -p0 < /tmp/rules.patch
 ---> Running in dee0d750b373
can't find file to patch at input line 3
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|--- debian/rules.orig  2015-09-07 18:00:08.000000000 +0900
|+++ debian/rules       2015-09-07 18:01:32.000000000 +0900
--------------------------
File to patch:
Skip this patch? [y]
Skipping patch.
2 out of 2 hunks ignored
Service 'ubuntu14.04' failed to build: The command '/bin/sh -c patch -p0 < /tmp/rules.patch' returned a non-zero code: 1
```

When run `apt-get source nginx`, we will get the current latest version even if we actually want to get a legacy version.
Then, in this case, we can not get version 1.9.4 specified in Dockerfile.

So I tried like `apt -get source nginx="1.9.4"`. But, version 1.9.4 is not exist anymore. :disappointed: 

Finally, I succeeded when bump it to latest(1.9.7).

In addition, bump ngx_mruby as well. it is not neccessary to work, but I'm happy when it is so. :sushi:  