### PR TITLE
bump version to 1.9.9

### DIFF
--- a/Dockerfile.centos6
+++ b/Dockerfile.centos6
@@ -9,7 +9,7 @@ RUN yum -y install rpm-build rpmdevtools yum-utils mercurial
 RUN wget https://s3.amazonaws.com/pkgr-buildpack-ruby/current/centos-6/ruby-2.2.3.tgz
 RUN tar xf ruby-2.2.3.tgz -C /usr/local
 
-ENV NGINX_VERSION 1.9.7
+ENV NGINX_VERSION 1.9.9
 ENV NGX_MRUBY_VERSION 1.15.0
 
 WORKDIR /usr/local/src

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -6,7 +6,7 @@ RUN yum -y groupinstall "Development Tools"
 RUN yum -y install rake openssl-devel wget
 RUN yum -y install rpm-build rpmdevtools yum-utils mercurial
 
-ENV NGINX_VERSION 1.9.7
+ENV NGINX_VERSION 1.9.9
 ENV NGX_MRUBY_VERSION 1.15.0
 
 WORKDIR /usr/local/src

--- a/Dockerfile.ubuntu1404
+++ b/Dockerfile.ubuntu1404
@@ -9,7 +9,7 @@ RUN apt-get install -y build-essential devscripts
 RUN apt-get install -y git ruby2.1 rake bison libssl-dev ruby-switch
 RUN ruby-switch --set ruby2.1
 
-ENV NGINX_VERSION 1.9.7
+ENV NGINX_VERSION 1.9.9
 ENV NGX_MRUBY_VERSION 1.15.0
 
 WORKDIR /usr/local/src

--- a/Dockerfile.ubuntu1504
+++ b/Dockerfile.ubuntu1504
@@ -9,7 +9,7 @@ RUN apt-get install -y build-essential devscripts
 RUN apt-get install -y git ruby2.1 rake bison libssl-dev ruby-switch
 RUN ruby-switch --set ruby2.1
 
-ENV NGINX_VERSION 1.9.7
+ENV NGINX_VERSION 1.9.9
 ENV NGX_MRUBY_VERSION 1.15.0
 
 WORKDIR /usr/local/src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,27 @@
 centos6:
   dockerfile: Dockerfile.centos6
   build: .
-  command: cp -a /root/rpmbuild/RPMS/x86_64/nginx-1.9.7-1.el6.ngx.x86_64.rpm /tmp/nginx-ngx_mruby-1.9.7-1.el6.ngx.x86_64.rpm
+  command: cp -a /root/rpmbuild/RPMS/x86_64/nginx-1.9.9-1.el6.ngx.x86_64.rpm /tmp/nginx-ngx_mruby-1.9.9-1.el6.ngx.x86_64.rpm
   volumes:
     - .:/tmp:rw
 
 centos7:
   dockerfile: Dockerfile.centos7
   build: .
-  command: cp -a /root/rpmbuild/RPMS/x86_64/nginx-1.9.7-1.el7.centos.ngx.x86_64.rpm /tmp/nginx-ngx_mruby-1.9.7-1.el7.centos.ngx.x86_64.rpm
+  command: cp -a /root/rpmbuild/RPMS/x86_64/nginx-1.9.9-1.el7.centos.ngx.x86_64.rpm /tmp/nginx-ngx_mruby-1.9.9-1.el7.centos.ngx.x86_64.rpm
   volumes:
     - .:/tmp:rw
 
 ubuntu1404:
   dockerfile: Dockerfile.ubuntu1404
   build: .
-  command: cp -a /usr/local/src/nginx_1.9.7-1~trusty_amd64.deb /tmp/nginx-ngx_mruby_1.9.7-1~trusty_amd64.deb
+  command: cp -a /usr/local/src/nginx_1.9.9-1~trusty_amd64.deb /tmp/nginx-ngx_mruby_1.9.9-1~trusty_amd64.deb
   volumes:
     - .:/tmp:rw
 
 ubuntu1504:
   dockerfile: Dockerfile.ubuntu1504
   build: .
-  command: cp -a /usr/local/src/nginx_1.9.7-1~vivid_amd64.deb /tmp/nginx-ngx_mruby_1.9.7-1~vivid_amd64.deb
+  command: cp -a /usr/local/src/nginx_1.9.9-1~vivid_amd64.deb /tmp/nginx-ngx_mruby_1.9.9-1~vivid_amd64.deb
   volumes:
     - .:/tmp:rw


### PR DESCRIPTION
Skip nginx 1.9.8 because it had the bug:

> #### http://nginx.org/en/CHANGES
> Changes with nginx 1.9.9                                         09 Dec 2015
>
>    *) Bugfix: proxying to unix domain sockets did not work when using
>       variables; the bug had appeared in 1.9.8.