### PR TITLE
Bump up version 1.9.13

### DIFF
--- a/Dockerfile.centos6
+++ b/Dockerfile.centos6
@@ -4,7 +4,7 @@ MAINTAINER hsbt@ruby-lang.org
 RUN yum -y install --enablerepo=extras epel-release
 RUN yum -y groupinstall "Development Tools"
 RUN yum -y install wget tar openssl-devel
-RUN yum -y install rpm-build rpmdevtools yum-utils mercurial
+RUN yum -y install rpm-build rpmdevtools yum-utils mercurial perl-ExtUtils-Embed
 
 RUN wget https://s3.amazonaws.com/pkgr-buildpack-ruby/current/centos-6/ruby-2.2.3.tgz
 RUN tar xf ruby-2.2.3.tgz -C /usr/local

--- a/Dockerfile.centos6
+++ b/Dockerfile.centos6
@@ -9,7 +9,7 @@ RUN yum -y install rpm-build rpmdevtools yum-utils mercurial
 RUN wget https://s3.amazonaws.com/pkgr-buildpack-ruby/current/centos-6/ruby-2.2.3.tgz
 RUN tar xf ruby-2.2.3.tgz -C /usr/local
 
-ENV NGINX_VERSION 1.9.12
+ENV NGINX_VERSION 1.9.13
 
 RUN wget http://nginx.org/packages/mainline/centos/6/SRPMS/nginx-$NGINX_VERSION-1.el6.ngx.src.rpm -P /tmp
 RUN rpm -Uvh /tmp/nginx-$NGINX_VERSION-1.el6.ngx.src.rpm

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -4,7 +4,7 @@ MAINTAINER hsbt@ruby-lang.org
 RUN yum -y install --enablerepo=extras epel-release
 RUN yum -y groupinstall "Development Tools"
 RUN yum -y install rake openssl-devel wget
-RUN yum -y install rpm-build rpmdevtools yum-utils mercurial
+RUN yum -y install rpm-build rpmdevtools yum-utils mercurial which
 
 ENV NGINX_VERSION 1.9.13
 

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -6,7 +6,7 @@ RUN yum -y groupinstall "Development Tools"
 RUN yum -y install rake openssl-devel wget
 RUN yum -y install rpm-build rpmdevtools yum-utils mercurial
 
-ENV NGINX_VERSION 1.9.12
+ENV NGINX_VERSION 1.9.13
 
 RUN wget http://nginx.org/packages/mainline/centos/7/SRPMS/nginx-$NGINX_VERSION-1.el7.ngx.src.rpm -P /tmp
 RUN rpm -Uvh /tmp/nginx-$NGINX_VERSION-1.el7.ngx.src.rpm

--- a/Dockerfile.ubuntu1404
+++ b/Dockerfile.ubuntu1404
@@ -12,7 +12,7 @@ RUN echo 'deb http://nginx.org/packages/mainline/ubuntu/ trusty nginx' >> /etc/a
 RUN echo 'deb-src http://nginx.org/packages/mainline/ubuntu/ trusty nginx' >> /etc/apt/sources.list
 RUN apt-get update
 
-ENV NGINX_VERSION 1.9.12
+ENV NGINX_VERSION 1.9.13
 
 WORKDIR /usr/local/src
 RUN apt-get build-dep -y nginx="$NGINX_VERSION"

--- a/Dockerfile.ubuntu1404
+++ b/Dockerfile.ubuntu1404
@@ -3,7 +3,7 @@ MAINTAINER hsbt@ruby-lang.org
 
 RUN apt-get install -y software-properties-common
 RUN add-apt-repository -y ppa:brightbox/ruby-ng
-RUN apt-get update && apt-get install -y git build-essential devscripts ruby2.1 rake bison libssl-dev ruby-switch wget libxslt-dev libgd-dev libgeoip-dev
+RUN apt-get update && apt-get install -y git build-essential devscripts ruby2.1 rake bison libssl-dev ruby-switch wget libxslt-dev libgd-dev libgeoip-dev libperl-dev
 RUN ruby-switch --set ruby2.1
 
 RUN wget http://nginx.org/keys/nginx_signing.key

--- a/Dockerfile.ubuntu1504
+++ b/Dockerfile.ubuntu1504
@@ -12,7 +12,7 @@ RUN echo 'deb http://nginx.org/packages/mainline/ubuntu/ vivid nginx' >> /etc/ap
 RUN echo 'deb-src http://nginx.org/packages/mainline/ubuntu/ vivid nginx' >> /etc/apt/sources.list
 RUN apt-get update
 
-ENV NGINX_VERSION 1.9.12
+ENV NGINX_VERSION 1.9.13
 
 WORKDIR /usr/local/src
 RUN apt-get build-dep -y nginx="$NGINX_VERSION"

--- a/Dockerfile.ubuntu1504
+++ b/Dockerfile.ubuntu1504
@@ -3,7 +3,7 @@ MAINTAINER hsbt@ruby-lang.org
 
 RUN apt-get install -y software-properties-common
 RUN add-apt-repository -y ppa:brightbox/ruby-ng
-RUN apt-get update && apt-get install -y git build-essential devscripts ruby2.1 rake bison libssl-dev ruby-switch wget libxslt-dev libgd-dev libgeoip-dev
+RUN apt-get update && apt-get install -y git build-essential devscripts ruby2.1 rake bison libssl-dev ruby-switch wget libxslt-dev libgd-dev libgeoip-dev libperl-dev
 RUN ruby-switch --set ruby2.1
 
 RUN wget http://nginx.org/keys/nginx_signing.key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,27 @@
 centos6:
   dockerfile: Dockerfile.centos6
   build: .
-  command: cp -a /root/rpmbuild/RPMS/x86_64/nginx-1.9.12-1.el6.ngx.x86_64.rpm /tmp/nginx-ngx_mruby-1.9.12-1.el6.ngx.x86_64.rpm
+  command: cp -a /root/rpmbuild/RPMS/x86_64/nginx-1.9.13-1.el6.ngx.x86_64.rpm /tmp/nginx-ngx_mruby-1.9.13-1.el6.ngx.x86_64.rpm
   volumes:
     - .:/tmp:rw
 
 centos7:
   dockerfile: Dockerfile.centos7
   build: .
-  command: cp -a /root/rpmbuild/RPMS/x86_64/nginx-1.9.12-1.el7.centos.ngx.x86_64.rpm /tmp/nginx-ngx_mruby-1.9.12-1.el7.centos.ngx.x86_64.rpm
+  command: cp -a /root/rpmbuild/RPMS/x86_64/nginx-1.9.13-1.el7.centos.ngx.x86_64.rpm /tmp/nginx-ngx_mruby-1.9.13-1.el7.centos.ngx.x86_64.rpm
   volumes:
     - .:/tmp:rw
 
 ubuntu1404:
   dockerfile: Dockerfile.ubuntu1404
   build: .
-  command: cp -a /usr/local/src/nginx_1.9.12-1~trusty_amd64.deb /tmp/nginx-ngx_mruby_1.9.12-1~trusty_amd64.deb
+  command: cp -a /usr/local/src/nginx_1.9.13-1~trusty_amd64.deb /tmp/nginx-ngx_mruby_1.9.13-1~trusty_amd64.deb
   volumes:
     - .:/tmp:rw
 
 ubuntu1504:
   dockerfile: Dockerfile.ubuntu1504
   build: .
-  command: cp -a /usr/local/src/nginx_1.9.12-1~vivid_amd64.deb /tmp/nginx-ngx_mruby_1.9.12-1~vivid_amd64.deb
+  command: cp -a /usr/local/src/nginx_1.9.13-1~vivid_amd64.deb /tmp/nginx-ngx_mruby_1.9.13-1~vivid_amd64.deb
   volumes:
     - .:/tmp:rw


### PR DESCRIPTION
Nginx-1.9.13 released.

```
Changes with nginx 1.9.13                                        29 Mar 2016

    *) Change: non-idempotent requests (POST, LOCK, PATCH) are no longer
       passed to the next server by default if a request has been sent to a
       backend; the "non_idempotent" parameter of the "proxy_next_upstream"
       directive explicitly allows retrying such requests.

    *) Feature: the ngx_http_perl_module can be built dynamically.

    *) Feature: UDP support in the stream module.

    *) Feature: the "aio_write" directive.

    *) Feature: now cache manager monitors number of elements in caches and
       tries to avoid cache keys zone overflows.

    *) Bugfix: "task already active" and "second aio post" alerts might
       appear in logs when using the "sendfile" and "aio" directives with
       subrequests.

    *) Bugfix: "zero size buf in output" alerts might appear in logs if
       caching was used and a client closed a connection prematurely.

    *) Bugfix: connections with clients might be closed needlessly if
       caching was used.
       Thanks to Justin Li.

    *) Bugfix: nginx might hog CPU if the "sendfile" directive was used on
       Linux or Solaris and a file being sent was changed during sending.

    *) Bugfix: connections might hang when using the "sendfile" and "aio
       threads" directives.

    *) Bugfix: in the "proxy_pass", "fastcgi_pass", "scgi_pass", and
       "uwsgi_pass" directives when using variables.
       Thanks to Piotr Sikora.

    *) Bugfix: in the ngx_http_sub_filter_module.

    *) Bugfix: if an error occurred in a cached backend connection, the
       request was passed to the next server regardless of the
       proxy_next_upstream directive.

    *) Bugfix: "CreateFile() failed" errors when creating temporary files on
       Windows.
```

I have not tested in ubuntu1504.
Because not released yet ubuntu1504.