### PR TITLE
update nginx-1.9.15

### DIFF
--- a/Dockerfile.centos6
+++ b/Dockerfile.centos6
@@ -9,7 +9,7 @@ RUN yum -y install rpm-build rpmdevtools yum-utils mercurial perl-ExtUtils-Embed
 RUN wget https://s3.amazonaws.com/pkgr-buildpack-ruby/current/centos-6/ruby-2.2.3.tgz
 RUN tar xf ruby-2.2.3.tgz -C /usr/local
 
-ENV NGINX_VERSION 1.9.14
+ENV NGINX_VERSION 1.9.15
 
 RUN wget http://nginx.org/packages/mainline/centos/6/SRPMS/nginx-$NGINX_VERSION-1.el6.ngx.src.rpm -P /tmp
 RUN rpm -Uvh /tmp/nginx-$NGINX_VERSION-1.el6.ngx.src.rpm

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -6,7 +6,7 @@ RUN yum -y groupinstall "Development Tools"
 RUN yum -y install rake openssl-devel wget
 RUN yum -y install rpm-build rpmdevtools yum-utils mercurial which
 
-ENV NGINX_VERSION 1.9.14
+ENV NGINX_VERSION 1.9.15
 
 RUN wget http://nginx.org/packages/mainline/centos/7/SRPMS/nginx-$NGINX_VERSION-1.el7.ngx.src.rpm -P /tmp
 RUN rpm -Uvh /tmp/nginx-$NGINX_VERSION-1.el7.ngx.src.rpm

--- a/Dockerfile.ubuntu1404
+++ b/Dockerfile.ubuntu1404
@@ -12,7 +12,7 @@ RUN echo 'deb http://nginx.org/packages/mainline/ubuntu/ trusty nginx' >> /etc/a
 RUN echo 'deb-src http://nginx.org/packages/mainline/ubuntu/ trusty nginx' >> /etc/apt/sources.list
 RUN apt-get update
 
-ENV NGINX_VERSION 1.9.14
+ENV NGINX_VERSION 1.9.15
 
 WORKDIR /usr/local/src
 RUN apt-get build-dep -y nginx="$NGINX_VERSION"

--- a/Dockerfile.ubuntu1504
+++ b/Dockerfile.ubuntu1504
@@ -12,7 +12,7 @@ RUN echo 'deb http://nginx.org/packages/mainline/ubuntu/ vivid nginx' >> /etc/ap
 RUN echo 'deb-src http://nginx.org/packages/mainline/ubuntu/ vivid nginx' >> /etc/apt/sources.list
 RUN apt-get update
 
-ENV NGINX_VERSION 1.9.14
+ENV NGINX_VERSION 1.9.15
 
 WORKDIR /usr/local/src
 RUN apt-get build-dep -y nginx="$NGINX_VERSION"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,27 @@
 centos6:
   dockerfile: Dockerfile.centos6
   build: .
-  command: cp -a /root/rpmbuild/RPMS/x86_64/nginx-1.9.14-1.el6.ngx.x86_64.rpm /tmp/nginx-ngx_mruby-1.9.14-1.el6.ngx.x86_64.rpm
+  command: cp -a /root/rpmbuild/RPMS/x86_64/nginx-1.9.15-1.el6.ngx.x86_64.rpm /tmp/nginx-ngx_mruby-1.9.15-1.el6.ngx.x86_64.rpm
   volumes:
     - .:/tmp:rw
 
 centos7:
   dockerfile: Dockerfile.centos7
   build: .
-  command: cp -a /root/rpmbuild/RPMS/x86_64/nginx-1.9.14-1.el7.centos.ngx.x86_64.rpm /tmp/nginx-ngx_mruby-1.9.14-1.el7.centos.ngx.x86_64.rpm
+  command: cp -a /root/rpmbuild/RPMS/x86_64/nginx-1.9.15-1.el7.centos.ngx.x86_64.rpm /tmp/nginx-ngx_mruby-1.9.15-1.el7.centos.ngx.x86_64.rpm
   volumes:
     - .:/tmp:rw
 
 ubuntu1404:
   dockerfile: Dockerfile.ubuntu1404
   build: .
-  command: cp -a /usr/local/src/nginx_1.9.14-1~trusty_amd64.deb /tmp/nginx-ngx_mruby_1.9.14-1~trusty_amd64.deb
+  command: cp -a /usr/local/src/nginx_1.9.15-1~trusty_amd64.deb /tmp/nginx-ngx_mruby_1.9.15-1~trusty_amd64.deb
   volumes:
     - .:/tmp:rw
 
 ubuntu1504:
   dockerfile: Dockerfile.ubuntu1504
   build: .
-  command: cp -a /usr/local/src/nginx_1.9.14-1~vivid_amd64.deb /tmp/nginx-ngx_mruby_1.9.14-1~vivid_amd64.deb
+  command: cp -a /usr/local/src/nginx_1.9.15-1~vivid_amd64.deb /tmp/nginx-ngx_mruby_1.9.15-1~vivid_amd64.deb
   volumes:
     - .:/tmp:rw


### PR DESCRIPTION
nginx-1.9.15 released.

```
Changes with nginx 1.9.15                                        19 Apr 2016

    *) Bugfix: "recv() failed" errors might occur when using HHVM as a
       FastCGI server.

    *) Bugfix: when using HTTP/2 and the "limit_req" or "auth_request"
       directives a timeout or a "client violated flow control" error might
       occur while reading client request body; the bug had appeared in
       1.9.14.

    *) Workaround: a response might not be shown by some browsers if HTTP/2
       was used and client request body was not fully read; the bug had
       appeared in 1.9.14.

    *) Bugfix: connections might hang when using the "aio threads"
       directive.
       Thanks to Mindaugas Rasiukevicius.
```

ref: http://nginx.org/en/CHANGES