### PR TITLE
nginx 1.11.0

### DIFF
--- a/Dockerfile.centos6
+++ b/Dockerfile.centos6
@@ -9,7 +9,7 @@ RUN yum -y install rpm-build rpmdevtools yum-utils mercurial perl-ExtUtils-Embed
 RUN wget https://s3.amazonaws.com/pkgr-buildpack-ruby/current/centos-6/ruby-2.2.3.tgz
 RUN tar xf ruby-2.2.3.tgz -C /usr/local
 
-ENV NGINX_VERSION 1.9.15
+ENV NGINX_VERSION 1.11.0
 
 RUN wget http://nginx.org/packages/mainline/centos/6/SRPMS/nginx-$NGINX_VERSION-1.el6.ngx.src.rpm -P /tmp
 RUN rpm -Uvh /tmp/nginx-$NGINX_VERSION-1.el6.ngx.src.rpm

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -6,7 +6,7 @@ RUN yum -y groupinstall "Development Tools"
 RUN yum -y install rake openssl-devel wget
 RUN yum -y install rpm-build rpmdevtools yum-utils mercurial which
 
-ENV NGINX_VERSION 1.9.15
+ENV NGINX_VERSION 1.11.0
 
 RUN wget http://nginx.org/packages/mainline/centos/7/SRPMS/nginx-$NGINX_VERSION-1.el7.ngx.src.rpm -P /tmp
 RUN rpm -Uvh /tmp/nginx-$NGINX_VERSION-1.el7.ngx.src.rpm

--- a/Dockerfile.ubuntu1404
+++ b/Dockerfile.ubuntu1404
@@ -12,7 +12,7 @@ RUN echo 'deb http://nginx.org/packages/mainline/ubuntu/ trusty nginx' >> /etc/a
 RUN echo 'deb-src http://nginx.org/packages/mainline/ubuntu/ trusty nginx' >> /etc/apt/sources.list
 RUN apt-get -qq update
 
-ENV NGINX_VERSION 1.9.15
+ENV NGINX_VERSION 1.11.0
 
 WORKDIR /usr/local/src
 RUN apt-get -qq build-dep -y nginx="$NGINX_VERSION"

--- a/Dockerfile.ubuntu1604
+++ b/Dockerfile.ubuntu1604
@@ -8,7 +8,7 @@ RUN echo 'deb http://nginx.org/packages/mainline/ubuntu/ xenial nginx' >> /etc/a
 RUN echo 'deb-src http://nginx.org/packages/mainline/ubuntu/ xenial nginx' >> /etc/apt/sources.list
 RUN apt-get -qq update
 
-ENV NGINX_VERSION 1.9.15
+ENV NGINX_VERSION 1.11.0
 
 WORKDIR /usr/local/src
 RUN apt-get -qq build-dep -y nginx="$NGINX_VERSION"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,21 @@
 centos6:
   dockerfile: Dockerfile.centos6
   build: .
-  command: cp -a /root/rpmbuild/RPMS/x86_64/nginx-1.9.15-1.el6.ngx.x86_64.rpm /tmp/nginx-ngx_mruby-1.9.15-1.el6.ngx.x86_64.rpm
+  command: cp -a /root/rpmbuild/RPMS/x86_64/nginx-1.11.0-1.el6.ngx.x86_64.rpm /tmp/nginx-ngx_mruby-1.11.0-1.el6.ngx.x86_64.rpm
   volumes:
     - .:/tmp:rw
 
 centos7:
   dockerfile: Dockerfile.centos7
   build: .
-  command: cp -a /root/rpmbuild/RPMS/x86_64/nginx-1.9.15-1.el7.centos.ngx.x86_64.rpm /tmp/nginx-ngx_mruby-1.9.15-1.el7.centos.ngx.x86_64.rpm
+  command: cp -a /root/rpmbuild/RPMS/x86_64/nginx-1.11.0-1.el7.centos.ngx.x86_64.rpm /tmp/nginx-ngx_mruby-1.11.0-1.el7.centos.ngx.x86_64.rpm
   volumes:
     - .:/tmp:rw
 
 ubuntu1404:
   dockerfile: Dockerfile.ubuntu1404
   build: .
-  command: cp -a /usr/local/src/nginx_1.9.15-1~trusty_amd64.deb /tmp/nginx-ngx_mruby_1.9.15-1~trusty_amd64.deb
+  command: cp -a /usr/local/src/nginx_1.11.0-1~trusty_amd64.deb /tmp/nginx-ngx_mruby_1.11.0-1~trusty_amd64.deb
   volumes:
     - .:/tmp:rw
 
@@ -29,6 +29,6 @@ ubuntu1504:
 ubuntu1604:
   dockerfile: Dockerfile.ubuntu1604
   build: .
-  command: cp -a /usr/local/src/nginx_1.9.15-1~xenial_amd64.deb /tmp/nginx-ngx_mruby_1.9.15-1~xenial_amd64.deb
+  command: cp -a /usr/local/src/nginx_1.11.0-1~xenial_amd64.deb /tmp/nginx-ngx_mruby_1.11.0-1~xenial_amd64.deb
   volumes:
     - .:/tmp:rw


### PR DESCRIPTION
see also: http://nginx.org/en/CHANGES

```
Changes with nginx 1.11.0                                        24 May 2016

    *) Feature: the "transparent" parameter of the "proxy_bind",
       "fastcgi_bind", "memcached_bind", "scgi_bind", and "uwsgi_bind"
       directives.

    *) Feature: the $request_id variable.

    *) Feature: the "map" directive supports combinations of multiple
       variables as resulting values.

    *) Feature: now nginx checks if EPOLLRDHUP events are supported by
       kernel, and optimizes connection handling accordingly if the "epoll"
       method is used.

    *) Feature: the "ssl_certificate" and "ssl_certificate_key" directives
       can be specified multiple times to load certificates of different
       types (for example, RSA and ECDSA).

    *) Feature: the "ssl_ecdh_curve" directive now allows specifying a list
       of curves when using OpenSSL 1.0.2 or newer; by default a list built
       into OpenSSL is used.

    *) Change: to use DHE ciphers it is now required to specify parameters
       using the "ssl_dhparam" directive.

    *) Feature: the $proxy_protocol_port variable.

    *) Feature: the $realip_remote_port variable in the
       ngx_http_realip_module.

    *) Feature: the ngx_http_realip_module is now able to set the client
       port in addition to the address.

    *) Change: the "421 Misdirected Request" response now used when
       rejecting requests to a virtual server different from one negotiated
       during an SSL handshake; this improves interoperability with some
       HTTP/2 clients when using client certificates.

    *) Change: HTTP/2 clients can now start sending request body
       immediately; the "http2_body_preread_size" directive controls size of
       the buffer used before nginx will start reading client request body.

    *) Bugfix: cached error responses were not updated when using the
       "proxy_cache_bypass" directive.
```