### PR TITLE
Update ngx_mruby to v1.18.3

### DIFF
--- a/Dockerfile.centos6
+++ b/Dockerfile.centos6
@@ -19,7 +19,7 @@ WORKDIR /root/rpmbuild/SPECS
 ADD ngx_mruby/centos/nginx.spec.patch /root/rpmbuild/SPECS/nginx.spec.patch
 RUN patch -p0 < nginx.spec.patch
 
-ENV NGX_MRUBY_VERSION 1.18.2
+ENV NGX_MRUBY_VERSION 1.18.3
 
 WORKDIR /usr/local/src
 RUN git clone --branch v$NGX_MRUBY_VERSION --depth 1 https://github.com/matsumoto-r/ngx_mruby.git

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -16,7 +16,7 @@ WORKDIR /root/rpmbuild/SPECS
 ADD ngx_mruby/centos/nginx.spec.patch /root/rpmbuild/SPECS/nginx.spec.patch
 RUN patch -p0 < nginx.spec.patch
 
-ENV NGX_MRUBY_VERSION 1.18.2
+ENV NGX_MRUBY_VERSION 1.18.3
 
 WORKDIR /usr/local/src
 RUN git clone --branch v$NGX_MRUBY_VERSION --depth 1 https://github.com/matsumoto-r/ngx_mruby.git

--- a/Dockerfile.ubuntu1404
+++ b/Dockerfile.ubuntu1404
@@ -18,7 +18,7 @@ WORKDIR /usr/local/src
 RUN apt-get -qq build-dep -y nginx="$NGINX_VERSION"
 RUN apt-get -qq source nginx="$NGINX_VERSION"
 
-ENV NGX_MRUBY_VERSION 1.18.2
+ENV NGX_MRUBY_VERSION 1.18.3
 
 WORKDIR /usr/local/src
 RUN git clone --branch v$NGX_MRUBY_VERSION --depth 1 https://github.com/matsumoto-r/ngx_mruby.git

--- a/Dockerfile.ubuntu1604
+++ b/Dockerfile.ubuntu1604
@@ -14,7 +14,7 @@ WORKDIR /usr/local/src
 RUN apt-get -qq build-dep -y nginx="$NGINX_VERSION"
 RUN apt-get -qq source nginx="$NGINX_VERSION"
 
-ENV NGX_MRUBY_VERSION 1.18.2
+ENV NGX_MRUBY_VERSION 1.18.3
 
 WORKDIR /usr/local/src
 RUN git clone --branch v$NGX_MRUBY_VERSION --depth 1 https://github.com/matsumoto-r/ngx_mruby.git


### PR DESCRIPTION
Update ngx_mruby to v1.18.3.

- See also: https://github.com/matsumoto-r/ngx_mruby/releases/tag/v1.18.3